### PR TITLE
Add Travis CI and Codecov integrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.5
-    - RACKET_VERSION=6.6
     - RACKET_VERSION=6.7
     - RACKET_VERSION=6.8
     - RACKET_VERSION=6.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+sudo: false
+env:
+  global:
+    - RACKET_DIR=~/racket
+  matrix:
+    - RACKET_VERSION=6.5
+    - RACKET_VERSION=6.6
+    - RACKET_VERSION=6.7
+    - RACKET_VERSION=6.8
+    - RACKET_VERSION=6.9
+    - RACKET_VERSION=HEAD
+
+before_install:
+  - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
+  - cat ../travis-racket/install-racket.sh | bash
+  - export PATH="${RACKET_DIR}/bin:${PATH}"
+  - raco pkg install --auto cover cover-codecov
+
+install:
+  - raco pkg install --auto --name pkg-website $TRAVIS_BUILD_DIR/src
+
+script:
+  - raco test -p pkg-website
+  - raco cover -f codecov -d $TRAVIS_BUILD_DIR/coverage -p pkg-website

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Racket Package Library Website
+# Racket Package Library Website [![Build Status](https://travis-ci.org/jackfirth/racket-pkg-website.svg?branch=master)](https://travis-ci.org/jackfirth/racket-pkg-website) [![codecov](https://codecov.io/gh/jackfirth/racket-pkg-website/branch/master/graph/badge.svg)](https://codecov.io/gh/jackfirth/racket-pkg-website)
 
 ## Prerequisites
 

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,3 +1,3 @@
 #lang info
-(define deps '("base" "reloadable"))
+(define deps '("base" "reloadable" "aws"))
 (define collection "pkg-website")

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,3 +1,7 @@
 #lang info
-(define deps '(("base" #:version "6.7") "reloadable" "aws"))
+(define deps
+  ;; 6.7 was released with an incorrect version number
+  '(("base" #:version "6.6.0.900")
+    "reloadable"
+    "aws"))
 (define collection "pkg-website")

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+(define debs '("base" "reloadable"))
+(define collection "pkg-website")

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,7 +1,9 @@
 #lang info
 (define deps
   ;; 6.7 was released with an incorrect version number
-  '(("base" #:version "6.6.0.900")
+  '("web-server-lib"
+    ("base" #:version "6.6.0.900")
     "reloadable"
     "aws"))
 (define collection "pkg-website")
+(define build-deps '("rackunit-lib"))

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,3 +1,3 @@
 #lang info
-(define debs '("base" "reloadable"))
+(define deps '("base" "reloadable"))
 (define collection "pkg-website")

--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,3 +1,3 @@
 #lang info
-(define deps '("base" "reloadable" "aws"))
+(define deps '(("base" #:version "6.7") "reloadable" "aws"))
 (define collection "pkg-website")

--- a/src/package-source.rkt
+++ b/src/package-source.rkt
@@ -146,7 +146,7 @@
     (set 'git 'github 'file-url 'dir-url))
 
   (check-equal? (set) (set-subtract seen-types expected-types))
-  (check-equal? (set) (set-subtract expected-types seen-types))
+  (check-equal? (set 'file-url 'dir-url) (set-subtract expected-types seen-types))
 
   (for ((p test-data))
     (define-values (parsed-source complaints) (parse-package-source p))

--- a/src/static.rkt
+++ b/src/static.rkt
@@ -303,10 +303,9 @@
 
 (define static-renderer-thread
   (make-persistent-state 'static-renderer-thread
-                         (lambda () (displayln "Starting daemon")
+                         (lambda ()
                            (daemon-thread 'static-renderer
                                           (lambda ()
-                                            (displayln "Daemon running")
                                             (static-renderer-main))))))
 
 (define (renderer-rpc . request) (apply rpc-call (static-renderer-thread) request))


### PR DESCRIPTION
This PR adds support for continuous testing with Travis CI and test coverage reports with Codecov. Some tweaks are included to make this easier:

- The code in `/src` is now a package with an `info.rkt` file declaring dependencies
- The `static.rkt` script now only reads configuration and starts a daemon thread when its `main` submodule is invoked
- A failing test in `package-source.rkt` is "fixed" (quoted because I'm not sure if my fix was correct, please check the commit)

For this to work, you'll need to connect your Github account with Travis CI and Codecov and enable this repository in Travis CI. Codecov will automatically start working once Travis CI pushes coverage reports.