### PR TITLE
Add testing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ Therefore, when using automatic code reloading, use just
 and make sure to run `make clean` beforehand, if you've run `make
 compile` at all previously.
 
+### Testing configuration
+
+The configuration that will be convenient for local testing is `testing`. 
+To use this configuration, you must create `pkgs-all.json.gz` at the root 
+of the project. You could do so with the following command:
+
+```
+$ wget https://pkgs.racket-lang.org/pkgs-all.json.gz
+$ mv pkgs-all.json.gz pkgs-all.json
+$ gzip pkgs-all.json
+```
+
+Then run by using the command
+
+```
+$ CONFIG=testing make compile run
+```
+
+The configuration enables the automatic code reloading described above.
+
 ## Deployment
 
 ### Static Content

--- a/configs/testing.rkt
+++ b/configs/testing.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+;; Configuration for development setup.
+(require racket/runtime-path
+         racket/format
+         racket/path
+         "../src/main.rkt")
+
+(define-runtime-path data-file "../pkgs-all.json.gz")
+
+(main (hash 'port 8444
+            'reloadable? #t
+            'package-index-url (~a "file://" (simple-form-path data-file))
+            'static-output-type 'file
+            'static-content-target-directory #f
+            'dynamic-urlprefix "https://localhost:8444"
+            'backend-baseurl "https://localhost:8445"
+            'disable-cache? #t
+            'pkg-index-generated-directory "/dummy/path/of/pkg-index"))


### PR DESCRIPTION
Provide a convenient testing configuration. Note that the steps to create
`pkgs-all.json.gz` locally could be skipped once #68 is fixed