### PR TITLE
Use longer password for key generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ clean:
 keys: private-key.pem server-cert.pem
 
 private-key.pem:
-	openssl genrsa -des3 -passout pass:a -out $@ 1024
-	openssl rsa -passin pass:a -in $@ -out $@
+	openssl genrsa -des3 -passout pass:dummy -out $@ 1024
+	openssl rsa -passin pass:dummy -in $@ -out $@
 
 server-cert.pem: private-key.pem
 	openssl req -new -x509 -nodes -sha1 -days 365 \
 		-subj /CN=beta.package.database.site \
-		-passin pass:a \
+		-passin pass:dummy \
 		-key private-key.pem > $@
 
 clean-keys:


### PR DESCRIPTION
Use longer password, "dummy", instead of "a", for key generation with
`make keys`.

When running `make keys`, I see error messages of the form

  routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:905:You
  must type in 4 to 1023 characters

and `private-key.pem` is generated with a length of 0 bytes.

According to https://bugzilla.redhat.com/show_bug.cgi?id=1467669 ,
this is because the used passwords are too short.