### PR TITLE
Keep forms alive via a larger continuation memory threshold

### DIFF
--- a/src/entrypoint.rkt
+++ b/src/entrypoint.rkt
@@ -26,8 +26,11 @@
                      #:port port
                      #:manager (make-threshold-LRU-manager
                                 on-continuation-expiry
-                                ;; This value is copied from web-server/servlet-env.rkt:
-                                (* 128 1024 1024))
+                                ;; The production service averages 200 - 350 MiB.
+                                ;; Using 512 MiB ensures e.g. forms live for a while without creating
+                                ;; too much memory pressure.
+                                ;; TODO: Make this configurable...?
+                                (* 512 1024 1024))
                      #:extra-files-paths (extra-files-paths)
                      #:ssl? ssl?
                      #:ssl-cert (and ssl? (build-path (current-directory) "../server-cert.pem"))

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -102,6 +102,9 @@
    ))
 
 (define (on-continuation-expiry request)
+  (log-warning "Tried to use expired continuation for ~a, current memory use: ~a"
+               (url->string (request-uri request))
+               (current-memory-use))
   (with-site-config
     (bootstrap-continuation-expiry-handler request)))
 


### PR DESCRIPTION
The LRU continuation manager's memory threshold was set to 128 MiB, but this is too low in practice, at least for the production service with recent versions of Racket, where `current-memory-use` is in the range of 200 - 350 MiB.

When the threshold is too low, all continuations expire after 2 minutes. In the case of the package creation form, it's quite likely you'll spend more than that time filling out the form, so this meant you'd have to start over and rush through quickly to get a new package added.

With this tuned memory value in place, most continuations should now stay alive for the maximum lifetime of 4 hours, which is much more usable.

Fixes https://github.com/racket/racket-pkg-website/issues/76