### PR TITLE
Disable display of author emails

### DIFF
--- a/src/site.rkt
+++ b/src/site.rkt
@@ -768,7 +768,10 @@
                                    #:id #f
                                    #:extra-classes `("selected-packages"))))
           (td (h2 ,(package-link (package-name pkg)))
-              ,(authors-list (package-authors pkg)))
+              ;; Temporarily disabled to prevent spammer scraping of emails.
+              ;; See https://github.com/racket/racket-pkg-website/issues/77
+              ;; for more discussion.
+              #;,(authors-list (package-authors pkg)))
           (td (p ,(if (string=? "" (package-description pkg))
                       `(span ((class "label label-warning")) "This package needs a description")
                       (package-description pkg)))
@@ -1074,7 +1077,10 @@
                    (pre ,err))])
 
           `(table ((class "package-details"))
-                  (tr (th "Authors")
+                  ;; Temporarily disabled to prevent spammer scraping of emails.
+                  ;; See https://github.com/racket/racket-pkg-website/issues/77
+                  ;; for more discussion.
+                  #;(tr (th "Authors")
                       (td (div ((class "authors-detail"))
                                ,(authors-list #:gravatars? #t (package-authors pkg)))))
                   (tr (th "Documentation")


### PR DESCRIPTION
The Racket package catalog shows author emails plainly without any redaction or mangling, making it easy for scrapers and scammers to harvest emails. My listed address has been getting tens of spam emails due to this exposure. The only other thing I've used that address for is to comment on the AUR, but the AUR user system does not expose the email address of members, so it's probably the Racket package server.

As comparison, here's what other package hosting sites do:
* OCaml opam does not expose emails
* Python pypi does expose emails
* RubyGems has an account system, but emails are not exposed on profiles
* Rust crates.io has an account system tied to GitHub profiles, emails are not exposed directly crates.io on profiles
* Java Maven central does not expose emails in the UI, but pom.xml files contain them

Altogether, I think we should hide these for now. Users can go to the codeforge/website of the package for contact information.

See issue #77 for more context and discussion.