### PR TITLE
Re-enable author display using hashed emails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,12 @@ clean:
 keys: private-key.pem server-cert.pem
 
 private-key.pem:
-	openssl genrsa -des3 -passout pass:a -out $@ 1024
-	openssl rsa -passin pass:a -in $@ -out $@
+	openssl genpkey -algorithm RSA -out $@
 
 server-cert.pem: private-key.pem
-	openssl req -new -x509 -nodes -sha1 -days 365 \
-		-subj /CN=beta.package.database.site \
-		-passin pass:a \
-		-key private-key.pem > $@
+	openssl req -new -x509 -days 365 \
+		-subj /CN=beta.package.database.localhost \
+		-key private-key.pem -out $@
 
 clean-keys:
 	rm -f private-key.pem server-cert.pem

--- a/src/display-name.rkt
+++ b/src/display-name.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+;; This module extends infrastructure-userdb/display-name with functions
+;; for rendering pretty HTML. They are designed to respect a potential
+;; future user preference for opting out of obfuscation.
+
+(require infrastructure-userdb/display-name
+         xml
+         racket/contract)
+
+(provide (all-from-out infrastructure-userdb/display-name)
+         (contract-out
+          [display-name->preferred-tag
+           (->* [display-name?]
+                [#:obfuscate? any/c]
+                symbol?)]
+          [display-name->xexpr
+           (->* [display-name?]
+                [#:obfuscate? any/c]
+                xexpr/c)]))
+
+(define (obfuscate-email-address? dn)
+  ;; TODO: implement a preference via infrastructure-userdb
+  #true)
+
+(define (display-name->preferred-tag dn #:obfuscate? [obfuscate? (obfuscate-email-address? dn)])
+  (if obfuscate?
+      (display-name-obfuscated-tag dn)
+      (display-name-plain-tag dn)))
+
+(define (display-name->xexpr dn  #:obfuscate? [obfuscate? (obfuscate-email-address? dn)])
+  (cond
+    [obfuscate?
+     `(span ()
+            ,(display-name-local-part dn)
+            (span ([class "text-muted"]
+                   [title "This author’s email address has been obfuscated."]
+                   [style "cursor: help;"])
+                  (b ([style "font: monospace;"])
+                     "λ")
+                  ,(display-name-short-hash dn)))]
+    [else
+     (display-name-email dn)]))

--- a/src/packages.rkt
+++ b/src/packages.rkt
@@ -25,6 +25,7 @@
 (require web-server/private/gzip)
 (require net/url)
 (require reloadable)
+(require infrastructure-userdb/display-name)
 (require "config.rkt")
 (require "daemon.rkt")
 (require "rpc.rkt")
@@ -271,7 +272,8 @@
   (sort-package-names (all-package-names)))
 
 (define (pkg->searchable-text pkg)
-  (string-join (flatten (list (or (@ pkg authors) '())
+  (string-join (flatten (list (for/list ([a (or (@ pkg authors) '())])
+                                (list a (display-name-obfuscated-email (email->display-name a))))
                               (map (match-lambda
                                     [(list _ path) path]
                                     [_ '()])

--- a/src/packages.rkt
+++ b/src/packages.rkt
@@ -101,9 +101,10 @@
   (define all-package-names (set-union (list->set (hash-keys local-packages))
                                        (list->set (hash-keys remote-packages))))
   (define new-local-packages
-    (for/fold ((acc (hash))) ((package-name all-package-names))
-      (define local-pkg (hash-ref local-packages package-name (lambda () #f)))
-      (define remote-pkg (hash-ref remote-packages package-name (lambda () #f)))
+    (for/fold ([acc (hash)])
+              ([package-name all-package-names])
+      (define local-pkg (hash-ref local-packages package-name #f))
+      (define remote-pkg (hash-ref remote-packages package-name #f))
       (define new-local-pkg
         (cond
          [(not local-pkg) remote-pkg]

--- a/src/randomness.rkt
+++ b/src/randomness.rkt
@@ -3,12 +3,9 @@
 (provide random-bytes
          random-bytes/base64)
 
-(require net/base64)
-
-(define (random-bytes n)
-  (with-input-from-file "/dev/urandom"
-    (lambda ()
-      (read-bytes n))))
+(require (rename-in racket/random
+                    [crypto-random-bytes random-bytes])
+         net/base64)
 
 (define (random-bytes/base64 n)
   (base64-encode (random-bytes n) #""))


### PR DESCRIPTION
This patch restores package author information to the web UI without
exposing email addresses to spammers. Email addresses are obfuscated
by combining the `local-part` of the email address (i.e. the part to
the left of the `@`, per RFC 5322 § 3.4.1) with the first seven
hexadecimal digits of the SHA-256 hash of the full address. Thus, for
example, the email address:

    philip@philipmcgrath.com

produces the obfuscated display name:

    philipλ9411372

Compared to alternative approaches, this design seems to have some
nice properties:

  1. We can continue to use email addresses as the “primary key” to
     identify users, rather than having to create and maintain a
     registry for usernames in a global namespace.

  2. In contrast to my comment on
     https://github.com/racket/racket-pkg-website/issues/77#issuecomment-1429252878
     proposing an optional user-specified display name (potentially
     with a disambiguator for collisions), this patch uses the
     identifier all users already have chosen. All users get
     meaningful, yet obfuscated, display names by default, with no
     action needed. We have no new data fields to store or validate.

  3. There is no ambiguity between email addresses and obfuscated
     display names.

  4. Anyone who knows an email address can compute the corresponding
     obfuscated display name and thus can search for packages
     associated with it. In some contexts one would want to use a
     UUID or a salted hash to avoid making that information
     discoverable. Here, though, our goal is to protect package
     authors from being spammed, not to conceal the authorship of
     Racket packages.

I took some inspiration from “Discord tags”/“discriminators” and from
identicons.

A natural extension would be to add a simple boolean preference
allowing users to choose whether to obfuscate their email addresses or
not. I’ve designed with that possibility in mind, but I also hope this
patch would be useful even without the further enhancement.

Related to https://github.com/racket/racket-pkg-website/issues/77
Related to https://github.com/racket/racket-pkg-website/pull/86
Related to 31aa7b0236a0597dc14cabd2b399a42723e93401
Related to https://github.com/racket/racket-pkg-website/issues/87

![Screenshot of the package index page showing `jesseλ31f2f5b`, `philipλ9411372`, and `lexi.lambdaλ81999a1`](https://user-images.githubusercontent.com/10700996/229336212-b899d24e-f00b-405f-9e90-e38991d05a35.png) ![Screenshot of the `basedir` package page showing `williamλ74e41ee` and `willghatchλ553d284`](https://user-images.githubusercontent.com/10700996/229336213-f496e270-e909-4c11-9cfd-2f22be3e2ef2.png)
